### PR TITLE
Get all dependencies from conda

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -3,8 +3,13 @@ channels:
   - conda-forge
   - httomo
 dependencies:
-  - conda-forge::cuda-version
+  - conda-forge::astra-toolbox
   - conda-forge::cupy=12.3.0
+  - conda-forge::h5py
+  - conda-forge::imageio
   - conda-forge::numpy<2
+  - conda-forge::nvtx
   - conda-forge::pyyaml
+  - conda-forge::scikit-image
+  - conda-forge::toml
   - conda-forge::tomopy=1.15

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -4,6 +4,7 @@ channels:
   - httomo
 dependencies:
   - conda-forge::cuda-version
+  - conda-forge::cupy=12.3.0
   - conda-forge::numpy<2
   - conda-forge::pyyaml
   - conda-forge::tomopy=1.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev_template = "{tag}"
 
 [project]
 name = "httomo-backends"
-version = "0.1.0"
+version = "0.1.1"
 description = "Supplementary files for HTTomo backends."
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}
@@ -50,7 +50,7 @@ dependencies = [
     "numpy<2",
     "pyyaml",
     "tomopy",
-    "cupy-cuda12x==12.3.0",
+    "cupy==12.3.0",
     "nvtx",
     "toml",
     "imageio",


### PR DESCRIPTION
The `cupy-cuda12x` dependency is dragged in by httomo when doing `pip install httomo-backends` in the IRIS CI workflow, and it causes issues with the GPU on IRIS nodes not being detectable, see the following failed workflow: https://github.com/DiamondLightSource/httomo/actions/runs/12694511591/job/35384845408.

So, this PR is opting to get `cupy` from conda (we already get `tomopy` from conda anyway), and see if this allows the httomo IRIS CI to pass in this PR where the methods database info have been removed from httomo and uses httomo-backends for that info instead: https://github.com/DiamondLightSource/httomo/pull/532