### PR TITLE
Try using non-CUDA container image for IRIS CI

### DIFF
--- a/.github/workflows/run_tests_iris.yml
+++ b/.github/workflows/run_tests_iris.yml
@@ -12,7 +12,7 @@ jobs:
   iris-gpu:
     runs-on: iris-gpu
     container:
-      image: nvidia/cuda:12.6.3-devel-ubi8
+      image: ghcr.io/catthehacker/ubuntu:act-22.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
 


### PR DESCRIPTION
An experiment in trying to not have CUDA in the container (to replicate the installation environment we use at DLS - we don't use any CUDA installed on the host, we only rely on whatever installing `cupy` from a conda channel does to the conda env).