### PR TITLE
Add missing `darks` and `flats` parameters to httomo loader YAML templates

### DIFF
--- a/httomo_backends/yaml_templates/httomo/httomo.data.hdf.loaders/standard_tomo.yaml
+++ b/httomo_backends/yaml_templates/httomo/httomo.data.hdf.loaders/standard_tomo.yaml
@@ -14,3 +14,5 @@
         # when null, the full data dimension is used, i.e., no previewing
         start: null
         stop: null
+    darks: null
+    flats: null

--- a/httomo_backends/yaml_templates/httomo/httomo.data.hdf.loaders/standard_tomo_diad.yaml
+++ b/httomo_backends/yaml_templates/httomo/httomo.data.hdf.loaders/standard_tomo_diad.yaml
@@ -14,3 +14,5 @@
         # when null, the full data dimension is used, i.e., no previewing
         start: null
         stop: null
+    darks: null
+    flats: null


### PR DESCRIPTION
Fixes #54