### PR TITLE
changes to accomodate fbp2d_astra method

### DIFF
--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
@@ -145,6 +145,15 @@ prep:
         method: module
 recon:
   algorithm:
+    FBP2d_astra:
+      pattern: sinogram
+      output_dims_change: True
+      implementation: gpu_cpu
+      save_result_default: True
+      padding: False
+      memory_gpu:
+        multiplier: None
+        method: module
     FBP:
       pattern: sinogram
       output_dims_change: True

--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
@@ -148,7 +148,7 @@ recon:
     FBP2d_astra:
       pattern: sinogram
       output_dims_change: True
-      implementation: gpu_cpu
+      implementation: gpu
       save_result_default: True
       padding: False
       memory_gpu:

--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
@@ -161,8 +161,8 @@ recon:
       save_result_default: True
       padding: False
       memory_gpu:
-        multiplier: None
-        method: module
+        multiplier: 1.0
+        method: direct
     SIRT3d_tomobar:
       pattern: sinogram
       output_dims_change: True

--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/recon/algorithm.py
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/recon/algorithm.py
@@ -26,11 +26,10 @@ import numpy as np
 from httomo_backends.cufft import CufftType, cufft_estimate_1d
 
 __all__ = [
-    "_calc_memory_bytes_FBP2d_astra",
     "_calc_memory_bytes_FBP3d_tomobar",
     "_calc_memory_bytes_SIRT3d_tomobar",
     "_calc_memory_bytes_CGLS3d_tomobar",
-    "_calc_output_dim_FBP2d_astra",  
+    "_calc_output_dim_FBP2d_astra",
     "_calc_output_dim_FBP3d_tomobar",
     "_calc_output_dim_SIRT3d_tomobar",
     "_calc_output_dim_CGLS3d_tomobar",
@@ -65,15 +64,6 @@ def _calc_output_dim_SIRT3d_tomobar(non_slice_dims_shape, **kwargs):
 
 def _calc_output_dim_CGLS3d_tomobar(non_slice_dims_shape, **kwargs):
     return __calc_output_dim_recon(non_slice_dims_shape, **kwargs)
-
-
-def _calc_memory_bytes_FBP2d_astra(
-    non_slice_dims_shape: Tuple[int, int],
-    dtype: np.dtype,
-    **kwargs,
-) -> Tuple[int, int]:
-    # this is GPU-CPU slice-by-slice reconstruction function so it doesn't need a lot of GPU memory
-    return (1, 0)
 
 
 def _calc_memory_bytes_FBP3d_tomobar(

--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/recon/algorithm.py
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/recon/algorithm.py
@@ -26,9 +26,11 @@ import numpy as np
 from httomo_backends.cufft import CufftType, cufft_estimate_1d
 
 __all__ = [
+    "_calc_memory_bytes_FBP2d_astra",
     "_calc_memory_bytes_FBP",
     "_calc_memory_bytes_SIRT",
     "_calc_memory_bytes_CGLS",
+    "_calc_output_dim_FBP2d_astra",
     "_calc_output_dim_FBP",
     "_calc_output_dim_SIRT",
     "_calc_output_dim_CGLS",
@@ -49,6 +51,10 @@ def __calc_output_dim_recon(non_slice_dims_shape, **kwargs):
     return output_dims
 
 
+def _calc_output_dim_FBP2d_astra(non_slice_dims_shape, **kwargs):
+    return __calc_output_dim_recon(non_slice_dims_shape, **kwargs)
+
+
 def _calc_output_dim_FBP(non_slice_dims_shape, **kwargs):
     return __calc_output_dim_recon(non_slice_dims_shape, **kwargs)
 
@@ -59,6 +65,15 @@ def _calc_output_dim_SIRT(non_slice_dims_shape, **kwargs):
 
 def _calc_output_dim_CGLS(non_slice_dims_shape, **kwargs):
     return __calc_output_dim_recon(non_slice_dims_shape, **kwargs)
+
+
+def _calc_memory_bytes_FBP2d_astra(
+    non_slice_dims_shape: Tuple[int, int],
+    dtype: np.dtype,
+    **kwargs,
+) -> Tuple[int, int]:
+    # this is GPU-CPU slice-by-slice reconstruction function so it doesn't need a lot of GPU memory
+    return (1, 0)
 
 
 def _calc_memory_bytes_FBP(

--- a/httomo_backends/methods_database/query.py
+++ b/httomo_backends/methods_database/query.py
@@ -101,13 +101,12 @@ class MethodsDatabaseQuery:
         p = self._get_method_info("output_dims_change")
         return bool(p)
 
-    def get_implementation(self) -> Literal["cpu", "gpu", "gpu_cupy", "gpu_cpu"]:
+    def get_implementation(self) -> Literal["cpu", "gpu", "gpu_cupy"]:
         p = self._get_method_info("implementation")
         assert p in [
             "gpu",
             "gpu_cupy",
             "cpu",
-            "gpu_cpu",
         ], f"The implementation arch {p} listed for method {self.module_path}.{self.method_name} is invalid"
         return p
 

--- a/httomo_backends/methods_database/query.py
+++ b/httomo_backends/methods_database/query.py
@@ -101,12 +101,13 @@ class MethodsDatabaseQuery:
         p = self._get_method_info("output_dims_change")
         return bool(p)
 
-    def get_implementation(self) -> Literal["cpu", "gpu", "gpu_cupy"]:
+    def get_implementation(self) -> Literal["cpu", "gpu", "gpu_cupy", "gpu_cpu"]:
         p = self._get_method_info("implementation")
         assert p in [
             "gpu",
             "gpu_cupy",
             "cpu",
+            "gpu_cpu",
         ], f"The implementation arch {p} listed for method {self.module_path}.{self.method_name} is invalid"
         return p
 

--- a/tests/test_httomolibgpu.py
+++ b/tests/test_httomolibgpu.py
@@ -25,7 +25,7 @@ from httomolibgpu.prep.stripe import (
 )
 from httomolibgpu.misc.corr import remove_outlier
 from httomolibgpu.misc.denoise import total_variation_ROF, total_variation_PD
-from httomolibgpu.recon.algorithm import FBP, SIRT, CGLS
+from httomolibgpu.recon.algorithm import FBP2d_astra, FBP, SIRT, CGLS
 from httomolibgpu.misc.rescale import rescale_to_int
 
 from httomo_backends.methods_database.packages.backends.httomolibgpu.supporting_funcs.misc.morph import *
@@ -728,3 +728,23 @@ def test_sino_360_to_180_memoryhook(
 
     assert estimated_bytes >= max_mem
     assert percentage_difference <= 35
+
+
+def test_FBP2d_astra_memory_calc():
+    # Call memory estimator to estimate memory usage
+    (estimated_bytes, subtract_bytes) = _calc_memory_bytes_FBP2d_astra(
+        non_slice_dims_shape=(10, 10),
+        dtype=np.float32(),
+    )
+    assert estimated_bytes == 1
+    assert subtract_bytes == 0
+
+
+def test_FBP2d_astra_output_dim():
+    # Call memory estimator to estimate memory usage
+    recon_size = 300
+    output_dims = _calc_output_dim_FBP2d_astra(
+        non_slice_dims_shape=(10, 10),
+        recon_size=recon_size,
+    )
+    assert output_dims == (recon_size, recon_size)

--- a/tests/test_httomolibgpu.py
+++ b/tests/test_httomolibgpu.py
@@ -25,7 +25,7 @@ from httomolibgpu.prep.stripe import (
 )
 from httomolibgpu.misc.corr import remove_outlier
 from httomolibgpu.misc.denoise import total_variation_ROF, total_variation_PD
-from httomolibgpu.recon.algorithm import FBP2d_astra, FBP3d_tomobar, SIRT3d_tomobar, CGLS3d_tomobar
+from httomolibgpu.recon.algorithm import FBP3d_tomobar, SIRT3d_tomobar, CGLS3d_tomobar
 from httomolibgpu.misc.rescale import rescale_to_int
 
 from httomo_backends.methods_database.packages.backends.httomolibgpu.supporting_funcs.misc.morph import *
@@ -728,16 +728,6 @@ def test_sino_360_to_180_memoryhook(
 
     assert estimated_bytes >= max_mem
     assert percentage_difference <= 35
-
-
-def test_FBP2d_astra_memory_calc():
-    # Call memory estimator to estimate memory usage
-    (estimated_bytes, subtract_bytes) = _calc_memory_bytes_FBP2d_astra(
-        non_slice_dims_shape=(10, 10),
-        dtype=np.float32(),
-    )
-    assert estimated_bytes == 1
-    assert subtract_bytes == 0
 
 
 def test_FBP2d_astra_output_dim():

--- a/tests/test_method_query.py
+++ b/tests/test_method_query.py
@@ -41,6 +41,11 @@ def test_httomolibgpu_implementation():
     assert query.get_implementation() == "gpu_cupy"
 
 
+def test_httomolibgpu_implementation2():
+    query = MethodsDatabaseQuery("httomolibgpu.recon.algorithm", "FBP2d_astra")
+    assert query.get_implementation() == "gpu_cpu"
+
+
 def test_httomolibgpu_output_dims_change():
     query = MethodsDatabaseQuery("httomolibgpu.prep.normalize", "normalize")
     assert query.get_output_dims_change() is False

--- a/tests/test_method_query.py
+++ b/tests/test_method_query.py
@@ -43,7 +43,7 @@ def test_httomolibgpu_implementation():
 
 def test_httomolibgpu_implementation2():
     query = MethodsDatabaseQuery("httomolibgpu.recon.algorithm", "FBP2d_astra")
-    assert query.get_implementation() == "gpu_cpu"
+    assert query.get_implementation() == "gpu"
 
 
 def test_httomolibgpu_output_dims_change():


### PR DESCRIPTION
Decided to go with the module (test_FBP2d_astra_memory_calc) which returns 1 byte, therefore enabling the size of the block that equals to a chunk. 
I believe if we to add more `gpu_cpu` 3d methods, then we need the actual memory estimators for them. So that way it differs from the `cpu` implementation, which doesn't have the module for memory estimation. 