### PR TITLE
fix: ignoring standard_tomo and standard_tomo_diad loaders for fullpi…

### DIFF
--- a/httomo_backends/scripts/json_pipelines_generator.py
+++ b/httomo_backends/scripts/json_pipelines_generator.py
@@ -22,7 +22,7 @@ result = process_all_yaml_files()
 # Directory containing YAML files relative to this script
 PIPELINES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "pipelines_full")
 
-ignored_methods = ["calculate_stats"]
+ignored_methods = ["standard_tomo_diad","standard_tomo","calculate_stats"]
 
 def get_yaml_path(yaml_filename: str) -> str:
     """


### PR DESCRIPTION
…pelines for avoiding duplicate loaders in config