### PR TITLE
Support for httomolibgpu's `remove_stripe_fw`

### DIFF
--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/httomolibgpu.yaml
@@ -135,6 +135,15 @@ prep:
       memory_gpu:
         multiplier: 1.17
         method: direct
+    remove_stripe_fw:
+      pattern: sinogram
+      output_dims_change: False
+      implementation: gpu_cupy
+      save_result_default: False
+      padding: False
+      memory_gpu:
+        multiplier: None
+        method: iterative
     remove_stripe_ti:
       pattern: sinogram
       output_dims_change: False

--- a/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/prep/stripe.py
+++ b/httomo_backends/methods_database/packages/backends/httomolibgpu/supporting_funcs/prep/stripe.py
@@ -25,9 +25,11 @@ from typing import Tuple
 import numpy as np
 
 from httomo_backends.cufft import CufftType, cufft_estimate_1d
+from httomolibgpu.prep.stripe import remove_stripe_fw
 
 
 __all__ = [
+    "_calc_memory_bytes_for_slices_remove_stripe_fw",
     "_calc_memory_bytes_remove_stripe_ti",
     "_calc_memory_bytes_remove_all_stripe",
     "_calc_memory_bytes_raven_filter",
@@ -51,6 +53,14 @@ def _calc_memory_bytes_remove_stripe_ti(
         in_slice_mem + slice_mean_mem + slice_fft_plan_mem + extra_temp_mem
     )
     return (tot_memory_bytes, gamma_mem)
+
+
+def _calc_memory_bytes_for_slices_remove_stripe_fw(
+    dims_shape: Tuple[int, int, int],
+    dtype: np.dtype,
+    **kwargs,
+) -> int:
+    return remove_stripe_fw(dims_shape, calc_peak_gpu_mem=True, **kwargs)
 
 
 def _calc_memory_bytes_remove_all_stripe(


### PR DESCRIPTION
- Requires https://github.com/DiamondLightSource/httomolibgpu/pull/239
- Adds `calculate_memory_bytes_for_slices` that can be used to estimate the device memory requirements of a function run on a 3D grid.
- Add support for `remove_stripe_fw` from httomolibgpu